### PR TITLE
Switch ordering of short-circuited OR on line 12.

### DIFF
--- a/tasks/gulpicon.js
+++ b/tasks/gulpicon.js
@@ -9,7 +9,7 @@ module.exports = function( files, config ) {
 
     // get the config
     config.logger = {
-      verbose: function() {} || config.verbose,
+      verbose: config.verbose || function() {},
       fatal: function() {},
       ok: function() {}
     };


### PR DESCRIPTION
The way this line was written, you couldn't actually provide a verbose function, because it would never fail the first part of the OR. By switching, the `config.verbose` option is passed along if supplied, and a backup function is provided if the option isn't supplied.
