### PR TITLE
Update grunticon-lib (fixes #9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "gulp-util": "^3.0.5",
     "through2": "^0.6.5",
-    "grunticon-lib": "1.2.0"
+    "grunticon-lib": "^1.2.1"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
I had the same issue as described here https://github.com/filamentgroup/gulpicon/issues/9 with the grunticon-loader not embedding SVGs. It seems it's fixed on grunticon-lib now so this change just updates the package.

Works for me, hope it works for you!
